### PR TITLE
Fix Bug: Playback indexes load properly so playbackSlider can function

### DIFF
--- a/OpenBCI_GUI/DataProcessing.pde
+++ b/OpenBCI_GUI/DataProcessing.pde
@@ -32,7 +32,7 @@ void process_input_file() throws Exception {
 
   try {
     while (!hasRepeated) {
-      currentTableRowIndex=getPlaybackDataFromTable(playbackData_table, currentTableRowIndex, cyton.get_scale_fac_uVolts_per_count(), cyton.get_scale_fac_accel_G_per_count(), dataPacketBuff[lastReadDataPacketInd]);
+      currentTableRowIndex = getPlaybackDataFromTable(playbackData_table, currentTableRowIndex, cyton.get_scale_fac_uVolts_per_count(), cyton.get_scale_fac_accel_G_per_count(), dataPacketBuff[lastReadDataPacketInd]);
 
       for (int Ichan=0; Ichan < nchan; Ichan++) {
         //scale the data into engineering units..."microvolts"

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -1101,6 +1101,11 @@ void haltSystem() {
   // eegDataSource = -1;
   //set all data source list items inactive
 
+  //Fix issue for processing successive playback files
+  indices = 0;
+  hasRepeated = false;
+  has_processed = false;
+
   //reset connect loadStrings
   openBCI_portName = "N/A";  // Fixes inability to reconnect after halding  JAM 1/2017
   ganglion_portName = "N/A";


### PR DESCRIPTION
Just need to reset indices, hasRepeated, and has_processed. This will work for a future playback widget also!