### PR TITLE
Deactivate Accel/Analog/Digital On/Off buttons when necessary

### DIFF
--- a/OpenBCI_GUI/AccelerometerCapableBoard.pde
+++ b/OpenBCI_GUI/AccelerometerCapableBoard.pde
@@ -5,5 +5,7 @@ interface AccelerometerCapableBoard {
 
     public void setAccelerometerActive(boolean active);
 
+    public boolean canDeactivateAccelerometer();
+
     public int[] getAccelerometerChannels();
 };

--- a/OpenBCI_GUI/AnalogCapableBoard.pde
+++ b/OpenBCI_GUI/AnalogCapableBoard.pde
@@ -5,5 +5,7 @@ interface AnalogCapableBoard {
 
     public void setAnalogActive(boolean active);
 
+    public boolean canDeactivateAnalog();
+
     public int[] getAnalogChannels();
 };

--- a/OpenBCI_GUI/BoardBrainFlowSynthetic.pde
+++ b/OpenBCI_GUI/BoardBrainFlowSynthetic.pde
@@ -45,6 +45,11 @@ implements AccelerometerCapableBoard, PPGCapableBoard, EDACapableBoard {
     }
 
     @Override
+    public boolean canDeactivateAccelerometer() {
+        return false;
+    }
+
+    @Override
     public int[] getAccelerometerChannels() {
         if (accelChannelsCache == null) {
             try {

--- a/OpenBCI_GUI/BoardCyton.pde
+++ b/OpenBCI_GUI/BoardCyton.pde
@@ -232,6 +232,11 @@ implements ImpedanceSettingsBoard, AccelerometerCapableBoard, AnalogCapableBoard
     }
 
     @Override
+    public boolean canDeactivateAccelerometer() {
+        return false;
+    }
+
+    @Override
     public int[] getAccelerometerChannels() {
         if (accelChannelsCache == null) {
             try {
@@ -253,9 +258,12 @@ implements ImpedanceSettingsBoard, AccelerometerCapableBoard, AnalogCapableBoard
     public void setAnalogActive(boolean active) {
         if(active) {
             setBoardMode(CytonBoardMode.ANALOG);
-        } else {
-            setBoardMode(CytonBoardMode.DEFAULT);
         }
+    }
+
+    @Override
+    public boolean canDeactivateAnalog() {
+        return false;
     }
 
     @Override
@@ -280,9 +288,12 @@ implements ImpedanceSettingsBoard, AccelerometerCapableBoard, AnalogCapableBoard
     public void setDigitalActive(boolean active) {
         if(active) {
             setBoardMode(CytonBoardMode.DIGITAL);
-        } else {
-            setBoardMode(CytonBoardMode.DEFAULT);
         }
+    }
+
+    @Override
+    public boolean canDeactivateDigital() {
+        return false;
     }
 
     @Override

--- a/OpenBCI_GUI/BoardCyton.pde
+++ b/OpenBCI_GUI/BoardCyton.pde
@@ -228,9 +228,7 @@ implements ImpedanceSettingsBoard, AccelerometerCapableBoard, AnalogCapableBoard
         if(active) {
             setBoardMode(CytonBoardMode.DEFAULT);
         }
-        else {
-            setBoardMode(CytonBoardMode.ANALOG);
-        }
+        // no way of turning off accel.
     }
 
     @Override

--- a/OpenBCI_GUI/BoardGanglion.pde
+++ b/OpenBCI_GUI/BoardGanglion.pde
@@ -118,6 +118,11 @@ abstract class BoardGanglion extends BoardBrainFlow implements AccelerometerCapa
     }
 
     @Override
+    public boolean canDeactivateAccelerometer() {
+        return true;
+    }
+
+    @Override
     public int[] getAccelerometerChannels() {
         if (accelChannelsCache == null) {
             try {

--- a/OpenBCI_GUI/BoardSynthetic.pde
+++ b/OpenBCI_GUI/BoardSynthetic.pde
@@ -117,6 +117,11 @@ class BoardSynthetic extends Board implements AccelerometerCapableBoard {
     }
 
     @Override
+    public boolean canDeactivateAccelerometer() {
+        return false;
+    }
+
+    @Override
     public void setEXGChannelActive(int channelIndex, boolean active) {
         exgChannelActive[channelIndex] = active;
     }

--- a/OpenBCI_GUI/DataSourcePlayback.pde
+++ b/OpenBCI_GUI/DataSourcePlayback.pde
@@ -252,6 +252,11 @@ class DataSourcePlayback implements DataSource, AccelerometerCapableBoard, Analo
     }
 
     @Override
+    public boolean canDeactivateAccelerometer() {
+        return false;
+    }
+
+    @Override
     public int[] getAccelerometerChannels() {
         if (underlyingBoard instanceof AccelerometerCapableBoard) {
             return ((AccelerometerCapableBoard)underlyingBoard).getAccelerometerChannels();
@@ -271,6 +276,11 @@ class DataSourcePlayback implements DataSource, AccelerometerCapableBoard, Analo
     }
 
     @Override
+    public boolean canDeactivateAnalog() {
+        return false;
+    }
+
+    @Override
     public int[] getAnalogChannels() {
         if (underlyingBoard instanceof AnalogCapableBoard) {
             return ((AnalogCapableBoard)underlyingBoard).getAnalogChannels();
@@ -287,6 +297,11 @@ class DataSourcePlayback implements DataSource, AccelerometerCapableBoard, Analo
     @Override
     public void setDigitalActive(boolean active) {
         // nothing
+    }
+
+    @Override
+    public boolean canDeactivateDigital() {
+        return false;
     }
 
     @Override

--- a/OpenBCI_GUI/DigitalCapableBoard.pde
+++ b/OpenBCI_GUI/DigitalCapableBoard.pde
@@ -5,5 +5,7 @@ interface DigitalCapableBoard {
 
     public void setDigitalActive(boolean active);
 
+    public boolean canDeactivateDigital();
+
     public int[] getDigitalChannels();
 };

--- a/OpenBCI_GUI/W_Accelerometer.pde
+++ b/OpenBCI_GUI/W_Accelerometer.pde
@@ -78,8 +78,7 @@ class W_Accelerometer extends Widget {
         accelerometerBar = new AccelerometerBar(_parent, accelXyzLimit, accelGraphX, accelGraphY, accelGraphWidth, accelGraphHeight);
         accelerometerBar.adjustTimeAxis(w_timeSeries.xLimOptions[settings.tsHorizScaleSave]); //sync horiz axis to Time Series by default
 
-        String accelButtonText = accelBoard.isAccelerometerActive() ? "Turn Accel. Off" : "Turn Accel. On";
-        accelModeButton = new Button_obci((int)(x + 3), (int)(y + 3 - navHeight), 120, navHeight - 6, accelButtonText, 12);
+        accelModeButton = new Button_obci((int)(x + 3), (int)(y + 3 - navHeight), 120, navHeight - 6, "", 12);
         accelModeButton.setCornerRoundess((int)(navHeight-6));
         accelModeButton.setFont(p5,12);
         accelModeButton.setColorNotPressed(color(57,128,204));
@@ -124,12 +123,20 @@ class W_Accelerometer extends Widget {
             lastAccelVals = accelerometerBar.getLastAccelVals();
         }
 
-        String accelMode = accelBoard.isAccelerometerActive() ? "Turn Accel. Off" : "Turn Accel. On";
-        accelModeButton.setString(accelMode);
+        accelModeButton.setString(getButtonString());
     }
 
     public float getLastAccelVal(int val) {
         return lastAccelVals[val];
+    }
+
+    String getButtonString() {	
+        if (accelBoard.isAccelerometerActive()) {	
+            return "Turn Accel. Off";	
+        }	
+        else {	
+            return "Turn Accel. On";	
+        }	
     }
 
     void draw() {
@@ -157,13 +164,10 @@ class W_Accelerometer extends Widget {
             drawAccValues();
             draw3DGraph();
             accelerometerBar.draw();
-
-            if (currentBoard instanceof BoardGanglion) {
-                accelModeButton.draw();
-            }
-        } else {
-            accelModeButton.draw();
         }
+
+        accelModeButton.draw();
+
         popStyle();
     }
 

--- a/OpenBCI_GUI/W_Accelerometer.pde
+++ b/OpenBCI_GUI/W_Accelerometer.pde
@@ -81,7 +81,6 @@ class W_Accelerometer extends Widget {
         accelModeButton = new Button_obci((int)(x + 3), (int)(y + 3 - navHeight), 120, navHeight - 6, "", 12);
         accelModeButton.setCornerRoundess((int)(navHeight-6));
         accelModeButton.setFont(p5,12);
-        accelModeButton.setColorNotPressed(color(57,128,204));
         accelModeButton.textColorNotActive = color(255);
         accelModeButton.hasStroke(false);
         accelModeButton.setHelpText("Click to activate/deactivate the accelerometer!");
@@ -123,20 +122,26 @@ class W_Accelerometer extends Widget {
             lastAccelVals = accelerometerBar.getLastAccelVals();
         }
 
-        accelModeButton.setString(getButtonString());
+        updateOnOffButton();
     }
 
     public float getLastAccelVal(int val) {
         return lastAccelVals[val];
     }
 
-    String getButtonString() {	
+    private void updateOnOffButton() {	
         if (accelBoard.isAccelerometerActive()) {	
-            return "Turn Accel. Off";	
-        }	
-        else {	
-            return "Turn Accel. On";	
-        }	
+            accelModeButton.setString("Turn Accel. Off");	
+            accelModeButton.setIgnoreHover(!accelBoard.canDeactivateAccelerometer());
+            if(!accelBoard.canDeactivateAccelerometer()) {
+                accelModeButton.setColorNotPressed(color(128));
+            }
+        }
+        else {
+            accelModeButton.setString("Turn Accel. On");	
+            accelModeButton.setIgnoreHover(false);
+            accelModeButton.setColorNotPressed(color(57,128,204));
+        }
     }
 
     void draw() {

--- a/OpenBCI_GUI/W_AnalogRead.pde
+++ b/OpenBCI_GUI/W_AnalogRead.pde
@@ -86,7 +86,6 @@ class W_AnalogRead extends Widget {
         analogModeButton = new Button_obci((int)(x + 3), (int)(y + 3 - navHeight), 128, navHeight - 6, "ANALOG TOGGLE", 12);
         analogModeButton.setCornerRoundess((int)(navHeight-6));
         analogModeButton.setFont(p5,12);
-        analogModeButton.setColorNotPressed(color(57,128,204));
         analogModeButton.textColorNotActive = color(255);
         analogModeButton.hasStroke(false);
         if (selectedProtocol == BoardProtocol.WIFI) {
@@ -122,6 +121,23 @@ class W_AnalogRead extends Widget {
             //ignore top left button interaction when widgetSelector dropdown is active
             ignoreButtonCheck(analogModeButton);
         }
+
+        updateOnOffButton();
+    }
+
+    private void updateOnOffButton() {	
+        if (analogBoard.isAnalogActive()) {	
+            analogModeButton.setString("Turn Analog Read Off");	
+            analogModeButton.setIgnoreHover(!analogBoard.canDeactivateAnalog());
+            if(!analogBoard.canDeactivateAnalog()) {
+                analogModeButton.setColorNotPressed(color(128));
+            }
+        }
+        else {
+            analogModeButton.setString("Turn Analog Read On");	
+            analogModeButton.setIgnoreHover(false);
+            analogModeButton.setColorNotPressed(color(57,128,204));
+        }
     }
 
     void draw() {
@@ -132,10 +148,7 @@ class W_AnalogRead extends Widget {
             pushStyle();
             //draw channel bars
             analogModeButton.draw();
-            if (!analogBoard.isAnalogActive()) {
-                analogModeButton.setString("Turn Analog Read On");
-            } else {
-                analogModeButton.setString("Turn Analog Read Off");
+            if (analogBoard.isAnalogActive()) {
                 for(int i = 0; i < numAnalogReadBars; i++) {
                     analogReadBars[i].draw();
                 }

--- a/OpenBCI_GUI/W_DigitalRead.pde
+++ b/OpenBCI_GUI/W_DigitalRead.pde
@@ -117,6 +117,23 @@ class W_DigitalRead extends Widget {
             //ignore top left button interaction when widgetSelector dropdown is active
             ignoreButtonCheck(digitalModeButton);
         }
+
+        updateOnOffButton();
+    }
+
+    private void updateOnOffButton() {	
+        if (digitalBoard.isDigitalActive()) {	
+            digitalModeButton.setString("Turn Digital Read Off");	
+            digitalModeButton.setIgnoreHover(!digitalBoard.canDeactivateDigital());
+            if(!digitalBoard.canDeactivateDigital()) {
+                digitalModeButton.setColorNotPressed(color(128));
+            }
+        }
+        else {
+            digitalModeButton.setString("Turn Digital Read On");	
+            digitalModeButton.setIgnoreHover(false);
+            digitalModeButton.setColorNotPressed(color(57,128,204));
+        }
     }
 
     void draw(){
@@ -127,10 +144,7 @@ class W_DigitalRead extends Widget {
             pushStyle();
             //draw channel bars
             digitalModeButton.draw();
-            if (!digitalBoard.isDigitalActive()) {
-                digitalModeButton.setString("Turn Digital Read On");
-            } else {
-                digitalModeButton.setString("Turn Digital Read Off");
+            if (digitalBoard.isDigitalActive()) {
                 for(int i = 0; i < numDigitalReadDots; i++){
                     digitalReadDots[i].draw();
                 }

--- a/OpenBCI_GUI/W_PulseSensor.pde
+++ b/OpenBCI_GUI/W_PulseSensor.pde
@@ -86,7 +86,6 @@ class W_PulseSensor extends Widget {
         analogModeButton = new Button_obci((int)(x + 3), (int)(y + 3 - navHeight), 128, navHeight - 6, "ANALOG TOGGLE", 12);
         analogModeButton.setCornerRoundess((int)(navHeight-6));
         analogModeButton.setFont(p5,12);
-        analogModeButton.setColorNotPressed(color(57,128,204));
         analogModeButton.textColorNotActive = color(255);
         analogModeButton.hasStroke(false);
         analogModeButton.setHelpText("Click this button to activate/deactivate analog read on Cyton.");
@@ -104,6 +103,23 @@ class W_PulseSensor extends Widget {
             int signal = (int)(allData.get(i)[analogChannels[0]]);
             processSignal(signal);
             PulseWaveY[i] = signal;
+        }
+
+        updateOnOffButton();
+    }
+
+    private void updateOnOffButton() {	
+        if (analogBoard.isAnalogActive()) {	
+            analogModeButton.setString("Turn Analog Read Off");	
+            analogModeButton.setIgnoreHover(!analogBoard.canDeactivateAnalog());
+            if(!analogBoard.canDeactivateAnalog()) {
+                analogModeButton.setColorNotPressed(color(128));
+            }
+        }
+        else {
+            analogModeButton.setString("Turn Analog Read On");	
+            analogModeButton.setIgnoreHover(false);
+            analogModeButton.setColorNotPressed(color(57,128,204));
         }
     }
 
@@ -133,10 +149,7 @@ class W_PulseSensor extends Widget {
         text("BPM "+BPM, BPMposX, BPMposY);
         text("IBI "+IBI+"mS", IBIposX, IBIposY);
 
-        if (!analogBoard.isAnalogActive()) {
-            analogModeButton.setString("Turn Analog Read On");
-        } else {
-            analogModeButton.setString("Turn Analog Read Off");
+        if (analogBoard.isAnalogActive()) {
             drawWaves();
         }
 


### PR DESCRIPTION
Added "boolean canDeactivateXXX" function to the Accel/Analog/Digital interfaces.

Deactivate and grey out the button accordingly.

It's generic, so it will work for all current (and future!) boards.